### PR TITLE
vrep points with rays

### DIFF
--- a/src/vecrep.jl
+++ b/src/vecrep.jl
@@ -243,6 +243,11 @@ function vrep(points::PointIt, lines::LineIt, rays::RayIt;
     return Hull(d, points, lines, rays)
 end
 
+function vrep(points::ElemIt{AT}, rays::ElemIt{Ray{T, AT}};
+              kws...) where {T, AT}
+    return vrep(points, Line{T, AT}[], rays; kws...)
+end
+
 function vrep(points::ElemIt{AT}, lines::ElemIt{Line{T, AT}};
               kws...) where {T, AT}
     return vrep(points, lines, Ray{T, AT}[]; kws...)


### PR DESCRIPTION
Need to add test, it came up when I tried doing `convexhull([1], Ray([1]))` but its output does not contain the origin in the points which is inconsistent with `convexhull([1], Ray([1]), Line([1]))`. Maybe convexhull with rays and lines should not be allowed, it's a bit ambiguous, `convexhull(points) + cone` and `convexhull(points, cone)` are less ambiguous.