### PR TITLE
Fix Plots.jl recipe to forward label and series_annotations (#356)

### DIFF
--- a/ext/PolyhedraRecipesBaseExt.jl
+++ b/ext/PolyhedraRecipesBaseExt.jl
@@ -5,7 +5,17 @@ import Polyhedra
 
 RecipesBase.@recipe function f(p::Polyhedra.Polyhedron)
     seriestype --> :shape
-    legend --> false
+
+    # Only hide the legend if the user DID NOT provide a custom label
+    if !haskey(plotattributes, :label)
+        legend --> false
+    end
+
+    # Explicitly force series_annotations to attach to the shape
+    if haskey(plotattributes, :series_annotations)
+        series_annotations := plotattributes[:series_annotations]
+    end
+   
     Polyhedra.planar_contour(p)
 end
 

--- a/test/recipe.jl
+++ b/test/recipe.jl
@@ -31,4 +31,22 @@ function recipetest(lib::Polyhedra.Library)
         p = polyhedron(h, lib)
         @test_throws err RecipesBase.apply_recipe(Dict{Symbol, Any}(), p)
     end
+
+    @testset "Plots.jl attribute forwarding" begin
+        # Creating a simple 2D polyhedron
+        v = vrep([0 0; 1 0; 0 1; 1 1])
+        p = polyhedron(v)
+
+        # Plotting it with custom attributes
+        plt = plot(p, label="Custom Label", series_annotations=["1", "2", "3", "4"])
+
+        # Extracting the first series from the first subplot
+        series = plt[1][1]
+
+        # Verifying our custom label wasn't overwritten by `legend --> false`
+        @test series[:label] == "Custom Label"
+
+        # Verifying series_annotations were successfully forwarded
+        @test haskey(series.plotattributes, :series_annotations) || haskey(series, :series_annotations)
+    end
 end

--- a/test/recipe.jl
+++ b/test/recipe.jl
@@ -37,16 +37,23 @@ function recipetest(lib::Polyhedra.Library)
         v = vrep([0 0; 1 0; 0 1; 1 1])
         p = polyhedron(v)
 
-        # Plotting it with custom attributes
-        plt = plot(p, label="Custom Label", series_annotations=["1", "2", "3", "4"])
+        # Simulating the user providing custom kwargs to plot()
+        # This is exactly what Plots.jl passes into the macro internally
+        attrs_with_label = Dict{Symbol, Any}(:label => "Custom Label", :series_annotations => ["1", "2", "3", "4"])
+    
+        # Calling the recipe directly without needing Plots.jl
+        # This returns an array of RecipeData objects
+        res_with_label = RecipesBase.apply_recipe(attrs_with_label, p)
+        series_attrs = res_with_label[1].plotattributes
 
-        # Extracting the first series from the first subplot
-        series = plt[1][1]
+        # Verifying custom label prevented `legend --> false` and annotations were kept
+        @test !haskey(series_attrs, :legend) || series_attrs[:legend] !== false
+        @test haskey(series_attrs, :series_annotations)
+        @test series_attrs[:series_annotations] == ["1", "2", "3", "4"]
 
-        # Verifying our custom label wasn't overwritten by `legend --> false`
-        @test series[:label] == "Custom Label"
-
-        # Verifying series_annotations were successfully forwarded
-        @test haskey(series.plotattributes, :series_annotations) || haskey(series, :series_annotations)
+        # Testing that if the user DOES NOT provide a label, legend defaults to false
+        attrs_no_label = Dict{Symbol, Any}()
+        res_no_label = RecipesBase.apply_recipe(attrs_no_label, p)
+        @test res_no_label[1].plotattributes[:legend] == false
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using Polyhedra
 
 using SparseArrays
 using LinearAlgebra
-using Plots
 using Test
 
 using StaticArrays

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Polyhedra
 
 using SparseArrays
 using LinearAlgebra
+using Plots
 using Test
 
 using StaticArrays


### PR DESCRIPTION
### Description
This PR addresses the feature request to support custom labels and vertex annotations when plotting polyhedra using `Plots.jl`. 

Previously, the plotting recipe in `PolyhedraRecipesBaseExt.jl` would swallow user-provided labels by defaulting to `legend --> false` and dropping the `series_annotations` before passing the geometry to `planar_contour`.

### Changes Made
- Added a `haskey` check on the invisible `plotattributes` dictionary to only apply `legend --> false` if the user did *not* provide a custom `:label`.
- Explicitly forwarded `:series_annotations` using the `:=` operator so they correctly attach to the final geometry.

### Testing
Tested locally using `Plots.jl` with a 2D `vrep` square. Confirmed that both the legend label and the individual vertex annotations now render successfully.

Closes #356